### PR TITLE
CURD Provider, search by name or id, paging, show provider detail

### DIFF
--- a/src/main/java/gr/careplus4/controllers/admin/provider/ProviderController.java
+++ b/src/main/java/gr/careplus4/controllers/admin/provider/ProviderController.java
@@ -1,0 +1,157 @@
+package gr.careplus4.controllers.admin.provider;
+
+import gr.careplus4.entities.Provider;
+import gr.careplus4.models.ProviderModel;
+import gr.careplus4.services.impl.ProviderServiceImpl;
+import jakarta.validation.Valid;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.ui.ModelMap;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Controller
+@RequestMapping("admin/provider")
+public class ProviderController {
+    @Autowired
+    ProviderServiceImpl providerService;
+
+    @RequestMapping("")
+    public String all(Model model, @RequestParam("page") Optional<Integer> page,
+                      @RequestParam("size") Optional<Integer> size) {
+        int currentPage = page.orElse(1);
+        int pageSize = size.orElse(10);
+
+        Pageable pageable = PageRequest.of(currentPage - 1, pageSize, Sort.by("id")); // Thay đổi nếu cần
+        Page<Provider> providerPage = providerService.findAll(pageable); // Lấy đối tượng Page<Provider>
+
+        model.addAttribute("providerPage", providerPage); // Truyền providerPage vào model
+        model.addAttribute("providers", providerPage.getContent());
+
+        int totalPages = providerPage.getTotalPages();
+        if (totalPages > 0) {
+            List<Integer> pageNumbers = IntStream.rangeClosed(1, totalPages)
+                    .boxed()
+                    .collect(Collectors.toList());
+            model.addAttribute("pageNumbers", pageNumbers);
+        }
+        return "admin/provider-list";
+    }
+
+    @GetMapping("/add")
+    public String add(Model model) {
+        ProviderModel pro = new ProviderModel();
+        model.addAttribute("pro", pro);
+        return "admin/provider-add";
+    }
+
+    @PostMapping("/save")
+    public ModelAndView save(ModelMap model, @Valid @ModelAttribute("pro") ProviderModel providerModel,
+                             BindingResult result) {
+        if (result.hasErrors()) {
+            System.out.println("Errors: " + result.getAllErrors());
+            return new ModelAndView("admin/provider-add");
+        }
+        Provider entity = new Provider();
+        BeanUtils.copyProperties(providerModel, entity);
+        entity.setId(null); // Đặt lại để chắc chắn ID được tự động generate
+        providerService.save(entity);
+        String message = "Provider added successfully";
+        model.addAttribute("message", message);
+        return new ModelAndView("redirect:/admin/provider", model);
+
+    }
+
+    @GetMapping("/edit/{id}")
+    public ModelAndView edit(ModelMap model, @PathVariable("id") String id) {
+        Optional<Provider> optionalProvider = providerService.findById(id);
+        ProviderModel pro = new ProviderModel();
+        if (optionalProvider.isPresent()) {
+            Provider entity = optionalProvider.get();
+            BeanUtils.copyProperties(entity, pro);
+            model.addAttribute("pro", pro);
+            return new ModelAndView("admin/provider-add", model);
+        }
+        model.addAttribute("mess", "Provider not found");
+        return new ModelAndView("forward:/admin/provider-list", model);
+    }
+
+    @GetMapping("/delete/{id}")
+    public String confirmDelete(Model model, @PathVariable("id") String id) {
+        Optional<Provider> optionalProvider = providerService.findById(id);
+        if (optionalProvider.isPresent()) {
+            model.addAttribute("pro", optionalProvider.get());
+            return "admin/provider-delete"; // Hiển thị trang xác nhận xóa
+        }
+        return "redirect:/admin/provider";
+    }
+
+    @PostMapping("/delete/{id}")
+    public String delete(@PathVariable("id") String id) {
+        providerService.deleteById(id);
+        return "redirect:/admin/provider";
+    }
+
+    @RequestMapping("/searchpaginated")
+    public String search(ModelMap model,
+                         @RequestParam(name="name", required = false) String name,
+                         @RequestParam(name = "id", required = false) String id,
+                         @RequestParam("page") Optional<Integer> page,
+                         @RequestParam("size") Optional<Integer> size) {
+
+        int currentPage = page.orElse(1);
+        int pageSize = size.orElse(3);
+
+        Pageable pageable = PageRequest.of(currentPage - 1, pageSize, Sort.by("id")); // Sửa Sort theo id
+
+        Page<Provider> resultPage;
+        if (StringUtils.hasText(name)) {
+            resultPage = providerService.findByNameContaining(name, pageable);
+            model.addAttribute("name", name);
+        } else if (StringUtils.hasText(id)) {
+            resultPage = providerService.findByIdContaining(id, pageable);
+            model.addAttribute("id", id);
+        }
+        else {
+            resultPage = providerService.findAll(pageable);
+        }
+
+        model.addAttribute("providerPage", resultPage);// Truyền providerPage vào model
+        model.addAttribute("providers", resultPage.getContent());
+
+        int totalPages = resultPage.getTotalPages();
+        if (totalPages > 0) {
+            List<Integer> pageNumbers = IntStream.rangeClosed(1, totalPages)
+                    .boxed()
+                    .collect(Collectors.toList());
+            model.addAttribute("pageNumbers", pageNumbers);
+        }
+        return "admin/provider-list";
+    }
+
+    @GetMapping("/show/{id}")
+    public ModelAndView show(ModelMap model, @PathVariable("id") String id) {
+        Optional<Provider> optionalProvider = providerService.findById(id);
+        if (optionalProvider.isPresent()) {
+            Provider provider = optionalProvider.get();
+            model.addAttribute("provider", provider); // Truyền dữ liệu provider sang view
+            return new ModelAndView("admin/provider-show", model); // Hiển thị trang chi tiết provider
+        }
+        model.addAttribute("mess", "Provider not found");
+        return new ModelAndView("redirect:/admin/provider", model); // Quay lại danh sách nếu không tìm thấy
+    }
+
+}

--- a/src/main/java/gr/careplus4/repositories/ProviderRepository.java
+++ b/src/main/java/gr/careplus4/repositories/ProviderRepository.java
@@ -1,0 +1,23 @@
+package gr.careplus4.repositories;
+
+import gr.careplus4.entities.Provider;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ProviderRepository extends JpaRepository<Provider, String> {
+    List<Provider> findByNameContaining (String name);
+    Page<Provider> findByNameContaining (String name, Pageable pageable);
+    Optional<Provider> findById(String id);
+    Page<Provider> findByIdContaining (String id, Pageable pageable);
+    Optional<Provider> findByName(String name);
+    Page<Provider> findAll (Pageable pageable);
+    boolean existsById(String id);
+    boolean existsByName(String name);
+    Provider findTopByOrderByIdDesc();
+}

--- a/src/main/java/gr/careplus4/services/iProviderService.java
+++ b/src/main/java/gr/careplus4/services/iProviderService.java
@@ -1,0 +1,25 @@
+package gr.careplus4.services;
+
+import gr.careplus4.entities.Provider;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public interface iProviderService {
+    Page<Provider> findAll(Pageable pageable);
+    List<Provider> findAll();
+    Page<Provider> findByNameContaining(String name, Pageable pageable);
+    <S extends Provider> S save(S entity);
+    void deleteById(String id);
+    Optional<Provider> findById(String id);
+    Optional<Provider> findByName(String name);
+    Provider findTopByOrderByIdDesc ();
+    Boolean existsById(String id);
+    Boolean existsByName(String name);
+    String generateProviderId(String previousId);
+    Page<Provider> findByIdContaining(String id, Pageable pageable);
+}

--- a/src/main/java/gr/careplus4/services/impl/ProviderServiceImpl.java
+++ b/src/main/java/gr/careplus4/services/impl/ProviderServiceImpl.java
@@ -1,0 +1,88 @@
+package gr.careplus4.services.impl;
+
+import gr.careplus4.entities.Manufacturer;
+import gr.careplus4.entities.Provider;
+import gr.careplus4.repositories.ProviderRepository;
+import gr.careplus4.services.GeneratedId;
+import gr.careplus4.services.iProviderService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ProviderServiceImpl implements iProviderService {
+
+    @Autowired
+    ProviderRepository providerRepository;
+
+    @Override
+    public Page<Provider> findAll(Pageable pageable) {
+        return providerRepository.findAll(pageable);
+    }
+
+    @Override
+    public List<Provider> findAll() {
+        return providerRepository.findAll();
+    }
+
+    @Override
+    public Page<Provider> findByNameContaining(String name, Pageable pageable) {
+        return providerRepository.findByNameContaining(name, pageable);
+    }
+
+    @Override
+    public <S extends Provider> S save(S entity) {
+        if (entity.getId() == null || entity.getId().trim().isEmpty()) //Loại bỏ mọi khoảng trắng ở đầu và cuối chuỗi id.
+        {
+            Provider lastProvider = findTopByOrderByIdDesc();
+            String previousProviderId = (lastProvider != null) ? lastProvider.getId() : "PRO0001";
+            entity.setId(generateProviderId(previousProviderId));
+        }
+        return providerRepository.save(entity);
+    }
+
+    @Override
+    public void deleteById(String id) {
+        providerRepository.deleteById(id);
+    }
+
+    @Override
+    public Optional<Provider> findById(String id) {
+        return providerRepository.findById(id);
+    }
+
+
+    @Override
+    public Optional<Provider> findByName(String name) {
+        return providerRepository.findByName(name);
+    }
+
+    @Override
+    public Provider findTopByOrderByIdDesc() {
+        return providerRepository.findTopByOrderByIdDesc();
+    }
+
+    @Override
+    public Boolean existsById(String id) {
+        return providerRepository.existsById(id);
+    }
+
+    @Override
+    public Boolean existsByName(String name) {
+        return providerRepository.existsByName(name);
+    }
+
+    @Override
+    public String generateProviderId(String previousId) {
+        return GeneratedId.getGeneratedId(previousId);
+    }
+
+    @Override
+    public Page<Provider> findByIdContaining(String id, Pageable pageable) {
+        return providerRepository.findByIdContaining(id, pageable);
+    }
+}


### PR DESCRIPTION
Cái này hoàn thiện được chức năng của thêm mới, xem danh sách, với xem chi tiết 1 nhà sản xuất.
Chức năng xóa chưa có kiểm tra coi provider này có nằm trong import nào chưa, này viết trong import
Chức năng edit khi edit thành công thì phần thông tin sau edit sẽ được xem là 1 provider mới và được tạo 1 id mới
1. Xem danh sách 
![image](https://github.com/user-attachments/assets/b369aaea-36cb-4df8-880e-daf997e058fd)
2. Xem chi tiết 1 nhà sản xuất 
![image](https://github.com/user-attachments/assets/670d73e7-f40a-4508-b9f0-1b983f52d659)
3. Thêm mới 1 nhà sản xuất (vd: PRO0023)
![image](https://github.com/user-attachments/assets/0ea6c628-8428-43d7-bfc1-e1b23233fc20)
4. Chỉnh sửa: PRO0022 là mẫu tin sau khi chỉnh sửa PRO0021 thành công được sinh ra

