### PR TITLE
Fix cart indicator value

### DIFF
--- a/src/main/resources/META-INF/resources/common/user/header-desktop.jsp
+++ b/src/main/resources/META-INF/resources/common/user/header-desktop.jsp
@@ -138,13 +138,23 @@
                             <%--                                    class="indicator__area"><svg width="20px" height="20px">--%>
                             <%--                                                    <use href="${URL}assets/images/sprite.svg#heart-20"></use>--%>
                             <%--                                                </svg> <span class="indicator__value">0</span></span></a></div>--%>
-                            <div class="indicator"><a href="${pageContext.request.contextPath}/user/cart"
-                                                      class="indicator__button"><span
-                                    class="indicator__area"><svg width="20px"
-                                                                 height="20px">
-                                                    <use href="${URL}assets/images/sprite.svg#cart-20"></use>
-                                                </svg> <span
-                                    class="indicator__value">${user.cart.productCount}</span></span></a>
+                            <div class="indicator">
+                                <a href="${pageContext.request.contextPath}/user/cart" class="indicator__button">
+                                    <span
+                                        class="indicator__area"><svg width="20px"
+                                                                     height="20px">
+                                                        <use href="${URL}assets/images/sprite.svg#cart-20"></use>
+                                                    </svg>
+                                        <c:choose>
+                                            <c:when test="${user.cart.productCount > 0}">
+                                                <span class="indicator__value">${user.cart.productCount} </span>
+                                            </c:when>
+                                            <c:otherwise>
+                                                <span class="indicator__value">0</span>
+                                            </c:otherwise>
+                                        </c:choose>
+                                    </span>
+                                </a>
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/META-INF/resources/common/user/header-mobile.jsp
+++ b/src/main/resources/META-INF/resources/common/user/header-mobile.jsp
@@ -188,12 +188,23 @@
 <%--                                                             height="20px">--%>
 <%--                                                <use xlink:href="${URL}assets/images/sprite.svg#heart-20"></use>--%>
 <%--                                            </svg> <span class="indicator__value">0</span></span></a></div>--%>
-                        <div class="indicator indicator--mobile"><a href="${URL}assets/cart.html"
-                                                                    class="indicator__button"><span
-                                class="indicator__area"><svg width="20px"
-                                                             height="20px">
-                                                <use xlink:href="/user/cart"></use>
-                                            </svg> <span class="indicator__value">${user.cart.productCount}</span></span></a></div>
+                        <div class="indicator indicator--mobile">
+                            <a href="${URL}assets/cart.html" class="indicator__button">
+                                <span class="indicator__area">
+                                    <svg width="20px" height="20px">
+                                        <use xlink:href="/user/cart"></use>
+                                    </svg>
+                                    <c:choose>
+                                        <c:when test="${user.cart.productCount > 0}">
+                                            <span class="indicator__value">${user.cart.productCount} </span>
+                                        </c:when>
+                                        <c:otherwise>
+                                            <span class="indicator__value">0</span>
+                                        </c:otherwise>
+                                    </c:choose>
+                                </span>
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This pull request includes updates to the cart indicator in both the desktop and mobile headers. The changes ensure that the cart indicator displays the correct product count and defaults to zero when the cart is empty.

Changes to cart indicator:

* [`src/main/resources/META-INF/resources/common/user/header-desktop.jsp`](diffhunk://#diff-565c16ad55288d41ab2dca0c2bd22f3110f2c6a2f5a2973ba7245b1ef4b0a3f0L141-R157): Updated the cart indicator to display the product count dynamically, showing zero when the cart is empty.
* [`src/main/resources/META-INF/resources/common/user/header-mobile.jsp`](diffhunk://#diff-41e6f927f9cd911ae8e9d7f4662c064d8f23f498122bebb0c7b7c6852870d9a3L191-R207): Updated the mobile cart indicator to display the product count dynamically, showing zero when the cart is empty.

![image](https://github.com/user-attachments/assets/73161eaa-c5b1-4e5e-8088-76e754e77c89)
